### PR TITLE
StatusNet -> Twitter

### DIFF
--- a/views/about.utml
+++ b/views/about.utml
@@ -1,8 +1,8 @@
-<p><b>Pump2Tweet</b> is a bridge to StatusNet sites.</p>
+<p><b>Pump2Tweet</b> is a bridge to Twitter.</p>
 
-<p>It lets you connect your pump.io account with your StatusNet account, and send your pump.io activities out through StatusNet.</p>
+<p>It lets you connect your pump.io account with your Twitter account, and send your pump.io activities out through Twitter.</p>
 
-<p>It also lets you find your friends from StatusNet who are already on the pump.io network, and follow them there, too.</p>
+<p>It also lets you find your friends from Twitter who are already on the pump.io network, and follow them there, too.</p>
 
 <p>Registering on this service lets your friends find you, too.</p>
 


### PR DESCRIPTION
In the live service pump2twitter.com the change is made, although it says "Twitter sites" in first line, and I think there's only one Twitter site, so for my proposal, I just used "Twitter".
